### PR TITLE
implement json.Marshaler interface on DashboardBuilder

### DIFF
--- a/dashboard.go
+++ b/dashboard.go
@@ -1,6 +1,8 @@
 package grabana
 
 import (
+	"encoding/json"
+
 	"github.com/K-Phoen/grabana/row"
 	"github.com/K-Phoen/grabana/variable/constant"
 	"github.com/K-Phoen/grabana/variable/custom"
@@ -66,6 +68,16 @@ func defaultTimePicker() DashboardBuilderOption {
 			TimeOptions:      []string{"5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"},
 		}
 	}
+}
+
+// MarshalJSON implements the encoding/json.Marshaler interface.
+//
+// This method can be used to render the dashboard into a JSON file
+// which your configuration management tool of choice can then feed into
+// Grafana's dashboard via its provisioning support.
+// See https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards
+func (builder *DashboardBuilder) MarshalJSON() ([]byte, error) {
+	return json.Marshal(builder.board)
 }
 
 // VariableAsConst adds a templated variable, defined as a set of constant


### PR DESCRIPTION
The use-case is as described in the code comment: I'm deploying Grafana dashboards using its builtin provisioning support, by supplying the dashboard JSON files through configuration management. I would like to use this library to generate those JSON files, but currently can't because the marshalable sdk.Board member is private inside DashboardBuilder. This commit exposes the json.Marshaler interface for DashboardBuilder to support the described usecase.