### PR TITLE
dashboard: add support for setting default time range and timezone of dashboards

### DIFF
--- a/dashboard/dashboard.go
+++ b/dashboard/dashboard.go
@@ -203,3 +203,18 @@ func AutoRefresh(interval string) Option {
 		builder.board.Refresh = &sdk.BoolString{Flag: true, Value: interval}
 	}
 }
+
+// Time defines the default time range for the dashboard, e.g. from "now-6h" to
+// "now".
+func Time(from, to string) Option {
+	return func(builder *Builder) {
+		builder.board.Time = sdk.Time{From: from, To: to}
+	}
+}
+
+// Timezone defines the default timezone for the dashboard, e.g. "utc".
+func Timezone(timezone string) Option {
+	return func(builder *Builder) {
+		builder.board.Timezone = timezone
+	}
+}

--- a/dashboard/dashboard_test.go
+++ b/dashboard/dashboard_test.go
@@ -96,6 +96,23 @@ func TestDashboardCanBeAutoRefreshed(t *testing.T) {
 	req.Equal("5s", panel.board.Refresh.Value)
 }
 
+func TestDashboardCanHaveTime(t *testing.T) {
+	req := require.New(t)
+
+	panel := New("", Time("now-6h", "now"))
+
+	req.Equal("now-6h", panel.board.Time.From)
+	req.Equal("now", panel.board.Time.To)
+}
+
+func TestDashboardCanHaveTimezone(t *testing.T) {
+	req := require.New(t)
+
+	panel := New("", Timezone("utc"))
+
+	req.Equal("utc", panel.board.Timezone)
+}
+
 func TestDashboardCanHaveTags(t *testing.T) {
 	req := require.New(t)
 	tags := []string{"generated", "grabana"}


### PR DESCRIPTION
This adds support for setting the default time range and timezone of dashboards.

This is useful to e.g. ensure dashboards are all UTC in order to match system
logs and other monitoring tools.