### PR TITLE
Allow setting refresh on datasource variables

### DIFF
--- a/variable/datasource/datasource.go
+++ b/variable/datasource/datasource.go
@@ -8,24 +8,19 @@ import (
 type Option func(constant *Datasource)
 
 const (
-	// Never will prevent the results from being refreshed.
-	Never int64 = 0
-
-	// DashboardLoad will refresh the results every time the dashboard is loaded.
-	DashboardLoad int64 = 1
-
-	// TimeChange will refresh the results every time the time interval changes.
-	TimeChange int64 = 2
+	// dashboardLoad will refresh the results every time the dashboard is loaded.
+	dashboardLoad int64 = 1
 )
 
-// Datasource represents a "query" templated variable.
+// Datasource represents a "datasource" templated variable.
 type Datasource struct {
 	Builder sdk.TemplateVar
 }
 
 // New creates a new "query" templated variable.
 func New(name string, options ...Option) *Datasource {
-	refreshValue := int64(DashboardLoad)
+	refreshValue := dashboardLoad
+
 	query := &Datasource{Builder: sdk.TemplateVar{
 		Name:  name,
 		Label: name,

--- a/variable/datasource/datasource.go
+++ b/variable/datasource/datasource.go
@@ -7,19 +7,15 @@ import (
 // Option represents an option that can be used to configure a query.
 type Option func(constant *Datasource)
 
-// RefreshInterval represents the interval at which the results of a query will
-// be refreshed.
-type RefreshInterval int
-
 const (
 	// Never will prevent the results from being refreshed.
-	Never RefreshInterval = 0
+	Never int64 = 0
 
 	// DashboardLoad will refresh the results every time the dashboard is loaded.
-	DashboardLoad RefreshInterval = 1
+	DashboardLoad int64 = 1
 
 	// TimeChange will refresh the results every time the time interval changes.
-	TimeChange RefreshInterval = 2
+	TimeChange int64 = 2
 )
 
 // Datasource represents a "query" templated variable.
@@ -29,13 +25,18 @@ type Datasource struct {
 
 // New creates a new "query" templated variable.
 func New(name string, options ...Option) *Datasource {
+	refreshValue := int64(DashboardLoad)
 	query := &Datasource{Builder: sdk.TemplateVar{
 		Name:  name,
 		Label: name,
 		Type:  "datasource",
+		Refresh: sdk.BoolInt{
+			Flag:  true,
+			Value: &refreshValue,
+		},
 	}}
 
-	for _, opt := range append([]Option{Refresh(DashboardLoad)}, options...) {
+	for _, opt := range options {
 		opt(query)
 	}
 
@@ -46,14 +47,6 @@ func New(name string, options ...Option) *Datasource {
 func Type(datasourceType string) Option {
 	return func(query *Datasource) {
 		query.Builder.Query = datasourceType
-	}
-}
-
-// Refresh defines the interval in which the values will be refreshed.
-func Refresh(refresh RefreshInterval) Option {
-	return func(query *Datasource) {
-		value := int64(refresh)
-		query.Builder.Refresh = sdk.BoolInt{Flag: true, Value: &value}
 	}
 }
 

--- a/variable/datasource/datasource.go
+++ b/variable/datasource/datasource.go
@@ -7,6 +7,21 @@ import (
 // Option represents an option that can be used to configure a query.
 type Option func(constant *Datasource)
 
+// RefreshInterval represents the interval at which the results of a query will
+// be refreshed.
+type RefreshInterval int
+
+const (
+	// Never will prevent the results from being refreshed.
+	Never RefreshInterval = 0
+
+	// DashboardLoad will refresh the results every time the dashboard is loaded.
+	DashboardLoad RefreshInterval = 1
+
+	// TimeChange will refresh the results every time the time interval changes.
+	TimeChange RefreshInterval = 2
+)
+
 // Datasource represents a "query" templated variable.
 type Datasource struct {
 	Builder sdk.TemplateVar
@@ -20,7 +35,7 @@ func New(name string, options ...Option) *Datasource {
 		Type:  "datasource",
 	}}
 
-	for _, opt := range options {
+	for _, opt := range append([]Option{Refresh(DashboardLoad)}, options...) {
 		opt(query)
 	}
 
@@ -31,6 +46,14 @@ func New(name string, options ...Option) *Datasource {
 func Type(datasourceType string) Option {
 	return func(query *Datasource) {
 		query.Builder.Query = datasourceType
+	}
+}
+
+// Refresh defines the interval in which the values will be refreshed.
+func Refresh(refresh RefreshInterval) Option {
+	return func(query *Datasource) {
+		value := int64(refresh)
+		query.Builder.Refresh = sdk.BoolInt{Flag: true, Value: &value}
 	}
 }
 

--- a/variable/datasource/datasource_test.go
+++ b/variable/datasource/datasource_test.go
@@ -66,6 +66,14 @@ func TestValuesCanBeFilteredByRegex(t *testing.T) {
 	req.Equal(regex, panel.Builder.Regex)
 }
 
+func TestValuesRefreshTimeCanBeSet(t *testing.T) {
+	req := require.New(t)
+
+	panel := New("", Refresh(TimeChange))
+
+	req.Equal(int64(TimeChange), *panel.Builder.Refresh.Value)
+}
+
 func TestDataSourceTypeCanBeSet(t *testing.T) {
 	req := require.New(t)
 

--- a/variable/datasource/datasource_test.go
+++ b/variable/datasource/datasource_test.go
@@ -14,6 +14,8 @@ func TestNewDatasourceVariablesCanBeCreated(t *testing.T) {
 	req.Equal("source", panel.Builder.Name)
 	req.Equal("source", panel.Builder.Label)
 	req.Equal("datasource", panel.Builder.Type)
+	req.Equal(DashboardLoad, *panel.Builder.Refresh.Value)
+	req.Equal(true, panel.Builder.Refresh.Flag)
 }
 
 func TestLabelCanBeSet(t *testing.T) {
@@ -64,14 +66,6 @@ func TestValuesCanBeFilteredByRegex(t *testing.T) {
 	panel := New("", Regex(regex))
 
 	req.Equal(regex, panel.Builder.Regex)
-}
-
-func TestValuesRefreshTimeCanBeSet(t *testing.T) {
-	req := require.New(t)
-
-	panel := New("", Refresh(TimeChange))
-
-	req.Equal(int64(TimeChange), *panel.Builder.Refresh.Value)
 }
 
 func TestDataSourceTypeCanBeSet(t *testing.T) {

--- a/variable/datasource/datasource_test.go
+++ b/variable/datasource/datasource_test.go
@@ -14,7 +14,7 @@ func TestNewDatasourceVariablesCanBeCreated(t *testing.T) {
 	req.Equal("source", panel.Builder.Name)
 	req.Equal("source", panel.Builder.Label)
 	req.Equal("datasource", panel.Builder.Type)
-	req.Equal(DashboardLoad, *panel.Builder.Refresh.Value)
+	req.Equal(dashboardLoad, *panel.Builder.Refresh.Value)
 	req.Equal(true, panel.Builder.Refresh.Flag)
 }
 


### PR DESCRIPTION
This is a direct copy of the same feature on query variables.
Not setting refresh on a datasource variable that uses another
variable results in a dashboard that fails to load unless you
"re-select" the variable in question.