### PR TITLE
Increase limit on number of listed folders

### DIFF
--- a/client.go
+++ b/client.go
@@ -142,7 +142,7 @@ func (client *Client) CreateFolder(ctx context.Context, name string) (*Folder, e
 
 // GetFolderByTitle finds a folder, given its title.
 func (client *Client) GetFolderByTitle(ctx context.Context, title string) (*Folder, error) {
-	resp, err := client.get(ctx, "/api/folders?limit=100")
+	resp, err := client.get(ctx, "/api/folders?limit=1000")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The default limit for results when calling `/api/folders` is 1000. This
increases the limit for client `GetFolderByTitle` to match that.

See https://grafana.com/docs/grafana/v7.5/http_api/folder/

`GetFolderByTitle` will still produce unexpected results if there are
more than 1000 folders. 