### PR TITLE
[flux] Use query instead of measurement for influx targets

### DIFF
--- a/decoder/testdata/graph_panel_influxdb_target.json
+++ b/decoder/testdata/graph_panel_influxdb_target.json
@@ -59,7 +59,7 @@
           "targets": [
             {
               "refId": "A",
-              "measurement": "buckets()"
+              "query": "buckets()"
             }
           ],
           "tooltip": {

--- a/target/influxdb/influxdb.go
+++ b/target/influxdb/influxdb.go
@@ -13,7 +13,7 @@ type InfluxDB struct {
 func New(query string, options ...Option) *InfluxDB {
 	influxdb := &InfluxDB{
 		Builder: &sdk.Target{
-			Measurement: query,
+			Query: query,
 		},
 	}
 

--- a/target/influxdb/influxdb_test.go
+++ b/target/influxdb/influxdb_test.go
@@ -12,7 +12,7 @@ func TestQueriesCanBeCreated(t *testing.T) {
 
 	target := influxdb.New("buckets()")
 
-	req.Equal("buckets()", target.Builder.Measurement)
+	req.Equal("buckets()", target.Builder.Query)
 }
 
 func TestRefCanBeConfigured(t *testing.T) {


### PR DESCRIPTION
The old (no longer supported) influx plugin have been replaced with a
native plugin by [grafana](https://grafana.com/grafana/plugins/influxdb/)