### PR TITLE
[wip] Initial structure for field overrides

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,3 +12,5 @@ require (
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
+
+replace github.com/K-Phoen/sdk => github.com/ptxmac/sdk v0.8.2-0.20211220183005-6bf8e9c10730

--- a/go.sum
+++ b/go.sum
@@ -285,6 +285,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+github.com/ptxmac/sdk v0.8.2-0.20211220183005-6bf8e9c10730 h1:3RpONO48H5e8IXTcaNRHs1v4g/wgnA8A8akDlvmfmZo=
+github.com/ptxmac/sdk v0.8.2-0.20211220183005-6bf8e9c10730/go.mod h1:fnbOsbRksULSfcXjOI6W1/HISz5o/u1iEhF/fLedqTg=
 github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be/go.mod h1:MIDFMn7db1kT65GmV94GzpX9Qdi7N/pQlwb+AN8wh+Q=
 github.com/rhysd/go-github-selfupdate v1.2.3 h1:iaa+J202f+Nc+A8zi75uccC8Wg3omaM7HDeimXA22Ag=
 github.com/rhysd/go-github-selfupdate v1.2.3/go.mod h1:mp/N8zj6jFfBQy/XMYoWsmfzxazpPAODuqarmPDe2Rg=

--- a/timeseries/fields/matcher.go
+++ b/timeseries/fields/matcher.go
@@ -1,0 +1,12 @@
+package fields
+
+import "github.com/K-Phoen/sdk"
+
+type Matcher func(field *sdk.FieldConfigOverride)
+
+func ByName(name string) Matcher {
+	return func(field *sdk.FieldConfigOverride) {
+		field.Matcher.ID = "byName"
+		field.Matcher.Options = name
+	}
+}

--- a/timeseries/fields/override.go
+++ b/timeseries/fields/override.go
@@ -1,0 +1,15 @@
+package fields
+
+import "github.com/K-Phoen/sdk"
+
+type OverrideOption func(field *sdk.FieldConfigOverride)
+
+func Unit(unit string) OverrideOption {
+	return func(field *sdk.FieldConfigOverride) {
+		field.Properties = append(field.Properties,
+			sdk.FieldConfigOverrideProperty{
+				ID:    "unit",
+				Value: unit,
+			})
+	}
+}

--- a/timeseries/timeseries.go
+++ b/timeseries/timeseries.go
@@ -3,6 +3,7 @@ package timeseries
 import (
 	"github.com/K-Phoen/grabana/alert"
 	"github.com/K-Phoen/grabana/timeseries/axis"
+	"github.com/K-Phoen/grabana/timeseries/fields"
 	"github.com/K-Phoen/sdk"
 )
 
@@ -303,5 +304,19 @@ func Alert(name string, opts ...alert.Option) Option {
 func Repeat(repeat string) Option {
 	return func(timeseries *TimeSeries) {
 		timeseries.Builder.Repeat = &repeat
+	}
+}
+
+func FieldOverride(m fields.Matcher, opts ...fields.OverrideOption) Option {
+	return func(timeseries *TimeSeries) {
+		override := sdk.FieldConfigOverride{}
+
+		m(&override)
+
+		for _, opt := range opts {
+			opt(&override)
+		}
+
+		timeseries.Builder.TimeseriesPanel.FieldConfig.Overrides = append(timeseries.Builder.TimeseriesPanel.FieldConfig.Overrides, override)
 	}
 }

--- a/vendor/github.com/K-Phoen/sdk/panel.go
+++ b/vendor/github.com/K-Phoen/sdk/panel.go
@@ -166,7 +166,8 @@ type (
 		FieldConfig     *FieldConfig     `json:"fieldConfig,omitempty"`
 	}
 	FieldConfig struct {
-		Defaults FieldConfigDefaults `json:"defaults"`
+		Defaults  FieldConfigDefaults   `json:"defaults"`
+		Overrides []FieldConfigOverride `json:"overrides"`
 	}
 	Options struct {
 		Orientation   string `json:"orientation"`
@@ -380,6 +381,17 @@ type (
 		Custom     FieldConfigCustom `json:"custom"`
 		Links      []Link            `json:"links,omitempty"`
 	}
+	FieldConfigOverrideProperty struct {
+		ID    string      `json:"id"`
+		Value interface{} `json:"value"`
+	}
+	FieldConfigOverride struct {
+		Matcher struct {
+			ID      string `json:"id"`
+			Options string `json:"options"`
+		} `json:"matcher"`
+		Properties []FieldConfigOverrideProperty `json:"properties"`
+	}
 	FieldConfigCustom struct {
 		AxisLabel         string `json:"axisLabel,omitempty"`
 		AxisPlacement     string `json:"axisPlacement"`
@@ -434,7 +446,7 @@ type (
 type (
 	// TODO look at schema versions carefully
 	// grid was obsoleted by xaxis and yaxes
-	grid struct { //nolint: unused,deadcode
+	grid struct { // nolint: unused,deadcode
 		LeftLogBase     *int     `json:"leftLogBase"`
 		LeftMax         *int     `json:"leftMax"`
 		LeftMin         *int     `json:"leftMin"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/K-Phoen/sdk v0.8.1
+# github.com/K-Phoen/sdk v0.8.1 => github.com/ptxmac/sdk v0.8.2-0.20211220183005-6bf8e9c10730
 ## explicit
 github.com/K-Phoen/sdk
 # github.com/blang/semver v3.5.1+incompatible
@@ -102,3 +102,4 @@ google.golang.org/protobuf/types/descriptorpb
 # gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 ## explicit
 gopkg.in/yaml.v3
+# github.com/K-Phoen/sdk => github.com/ptxmac/sdk v0.8.2-0.20211220183005-6bf8e9c10730


### PR DESCRIPTION
Depends on https://github.com/K-Phoen/sdk/pull/2

This PR is just a request for comments on the design/structure.

Sample use:
```go
dashboard.Row("Ping",
  row.WithTimeSeries("Ping",
    timeseries.WithInfluxDBTarget(query),
    timeseries.FieldOverride(fields.ByName("maximum_response_ms"), fields.Unit("ms")),
    timeseries.FieldOverride(fields.ByName("percent_packet_loss"), fields.Unit("percent")),
    ),
  )
```

Assume the above query returns two series named `maximum_response_ms` and `percent_packet_loss`, then this change allows the units to be specified for each series.