### PR TITLE
datasource/influxdb: add influxQL datasource support

### DIFF
--- a/datasource/influxdb/influxql.go
+++ b/datasource/influxdb/influxql.go
@@ -1,0 +1,49 @@
+package influxdb
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/K-Phoen/sdk"
+)
+
+type InfluxQL struct {
+	builder *sdk.Datasource
+}
+
+type Option func(datasource *InfluxQL)
+
+func New(name, url string, options ...Option) InfluxQL {
+	datasource := InfluxQL{
+		builder: &sdk.Datasource{
+			Name:   name,
+			Type:   "influxdb",
+			Access: "proxy",
+			URL:    url,
+			JSONData: map[string]interface{}{
+				"version": "InfluxQL",
+			},
+			SecureJSONData: map[string]interface{}{},
+		},
+	}
+
+	defaultOptions := []Option{
+		HTTPMethod(http.MethodGet),
+		AccessMode(Proxy),
+		MaxSeries(1000),
+	}
+
+	for _, opt := range append(defaultOptions, options...) {
+		opt(&datasource)
+	}
+
+	return datasource
+}
+
+func (datasource InfluxQL) Name() string {
+	return datasource.builder.Name
+}
+
+func (datasource InfluxQL) MarshalJSON() ([]byte, error) {
+	return json.Marshal(datasource.builder)
+}

--- a/datasource/influxdb/influxql_test.go
+++ b/datasource/influxdb/influxql_test.go
@@ -1,0 +1,30 @@
+package influxdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewInfluxQL(t *testing.T) {
+	req := require.New(t)
+
+	datasource := New("ds-name", "http://localhost:9090")
+
+	req.Equal("ds-name", datasource.Name())
+	req.Equal("http://localhost:9090", datasource.builder.URL)
+	req.Equal("influxdb", datasource.builder.Type)
+	req.Equal("proxy", datasource.builder.Access)
+	req.Equal(
+		map[string]interface{}{
+			"version":    "InfluxQL",
+			"httpMethod": "GET",
+			"maxSeries":  1000,
+		},
+		datasource.builder.JSONData,
+	)
+	req.NotNil(datasource.builder.SecureJSONData)
+
+	_, err := datasource.MarshalJSON()
+	req.NoError(err)
+}

--- a/datasource/influxdb/options.go
+++ b/datasource/influxdb/options.go
@@ -1,0 +1,145 @@
+package influxdb
+
+import (
+	"strings"
+	"time"
+)
+
+type Access string
+
+const (
+	Proxy   Access = "proxy"
+	Browser Access = "direct"
+)
+
+// Default configures this datasource to be the default one.
+func Default() Option {
+	return func(datasource *InfluxQL) {
+		datasource.builder.IsDefault = true
+	}
+}
+
+// HTTPMethod defines the Method used to query the database (GET or POST HTTP verb).
+// The POST verb allows heavy queries that would return an error using the GET verb.
+// Default is GET.
+func HTTPMethod(method string) Option {
+	return setJSONData("httpMethod", strings.ToUpper(method))
+}
+
+// AccessMode controls how requests to the data source will be handled. Proxy
+// should be the preferred way if nothing else is stated. Browser will let your
+// browser send the requests (deprecated).
+func AccessMode(mode Access) Option {
+	return func(datasource *InfluxQL) {
+		datasource.builder.Access = string(mode)
+	}
+}
+
+// KeepCookies controls the cookies that will be forwarded to the data source.
+// All other cookies will be deleted.
+func KeepCookies(cookies []string) Option {
+	return setJSONData("keepCookies", cookies)
+}
+
+// Timeout sets the timeout for HTTP requests.
+func Timeout(timeout time.Duration) Option {
+	return setJSONData("timeout", int(timeout.Seconds()))
+}
+
+// Database sets the ID of the bucket you want to query from,
+// copied from the Buckets page of the InfluxDB UI.
+func Database(database string) Option {
+	return func(datasource *InfluxQL) {
+		datasource.builder.Database = &database
+	}
+}
+
+// User sets username to use to sign into InfluxDB.
+func User(user string) Option {
+	return func(datasource *InfluxQL) {
+		datasource.builder.User = &user
+	}
+}
+
+// Password sets token you use to query the selected bucked,
+// copied from the Tokens page of the InfluxDB UI.
+func Password(password string) Option {
+	return setSecureJSONData("password", password)
+}
+
+// MinTimeInterval defines a lower limit for the auto group by time interval.
+// Recommended to be set to write frequency, for example 1m if your data is written every minute.
+func MinTimeInterval(interval time.Duration) Option {
+	return setJSONData("timeInterval", interval.String())
+}
+
+// MaxSeries limits the number of series/tables that Grafana processes.
+// Lower this number to prevent abuse, and increase it if you have lots of small time series
+// and not all are shown. Defaults to 1000.
+func MaxSeries(max int) Option {
+	return setJSONData("maxSeries", max)
+}
+
+// BasicAuth configures basic authentication for this datasource.
+func BasicAuth(username string, password string) Option {
+	return func(datasource *InfluxQL) {
+		yep := true
+		datasource.builder.BasicAuth = &yep
+		datasource.builder.BasicAuthUser = &username
+		datasource.builder.BasicAuthPassword = &password
+	}
+}
+
+// WithCredentials joins credentials such as cookies or auth headers to cross-site requests.
+func WithCredentials() Option {
+	return func(datasource *InfluxQL) {
+		datasource.builder.WithCredentials = true
+	}
+}
+
+// SkipTLSVerify disables verification of SSL certificates.
+func SkipTLSVerify() Option {
+	return setJSONData("tlsSkipVerify", true)
+}
+
+// ForwardOauthIdentity forward the user's upstream OAuth identity to the datasource.
+func ForwardOauthIdentity() Option {
+	return setJSONData("oauthPassThru", true)
+}
+
+// TLSClientAuth enables TLS client side authentication. Expects PEM encoded content.
+func TLSClientAuth(cert, key string) Option {
+	return multiOption(
+		setJSONData("tlsAuth", true),
+		setSecureJSONData("tlsClientCert", cert),
+		setSecureJSONData("tlsClientKey", key),
+	)
+}
+
+// WithCACert allows to provide a PEM encoded CA certificate to trust for this data source.
+func WithCACert(cert string) Option {
+	return multiOption(
+		setJSONData("tlsAuthWithCACert", true),
+		setSecureJSONData("tlsCACert", cert),
+	)
+}
+
+func multiOption(opts ...Option) Option {
+	return func(datasource *InfluxQL) {
+		for _, opt := range opts {
+			opt(datasource)
+		}
+	}
+}
+
+func setJSONData(key string, value interface{}) Option {
+	return func(datasource *InfluxQL) {
+		datasource.builder.JSONData.(map[string]interface{})[key] = value
+	}
+}
+
+func setSecureJSONData(key string, value interface{}) Option {
+	return func(datasource *InfluxQL) {
+		datasource.builder.SecureJSONData.(map[string]interface{})[key] = value
+	}
+}

--- a/datasource/influxdb/options_test.go
+++ b/datasource/influxdb/options_test.go
@@ -1,0 +1,135 @@
+package influxdb
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefault(t *testing.T) {
+	req := require.New(t)
+
+	datasource := New("", "", Default())
+
+	req.True(datasource.builder.IsDefault)
+}
+
+func TestHTTPMethod(t *testing.T) {
+	req := require.New(t)
+
+	datasource := New("", "", HTTPMethod(http.MethodPost))
+	req.Equal(http.MethodPost, datasource.builder.JSONData.(map[string]interface{})["httpMethod"])
+}
+
+func TestAccessMode(t *testing.T) {
+	req := require.New(t)
+
+	datasource := New("", "", AccessMode(Browser))
+	req.Equal(string(Browser), datasource.builder.Access)
+}
+
+func TestKeepCookies(t *testing.T) {
+	req := require.New(t)
+
+	datasource := New("", "", KeepCookies([]string{"foo", "bar"}))
+	req.Equal([]string{"foo", "bar"}, datasource.builder.JSONData.(map[string]interface{})["keepCookies"])
+}
+
+func TestTimeout(t *testing.T) {
+	req := require.New(t)
+
+	datasource := New("", "", Timeout(10*time.Second))
+	req.Equal(10, datasource.builder.JSONData.(map[string]interface{})["timeout"])
+}
+
+func TestDatabase(t *testing.T) {
+	req := require.New(t)
+
+	datasource := New("", "", Database("lolilol"))
+	req.Equal(stringPtr("lolilol"), datasource.builder.Database)
+}
+
+func TestUser(t *testing.T) {
+	req := require.New(t)
+
+	datasource := New("", "", User("lolilol"))
+	req.Equal(stringPtr("lolilol"), datasource.builder.User)
+}
+
+func TestPassword(t *testing.T) {
+	req := require.New(t)
+
+	datasource := New("", "", Password("whereisthepoulette"))
+	req.Equal("whereisthepoulette", datasource.builder.SecureJSONData.(map[string]interface{})["password"])
+}
+
+func TestMinTimeInterval(t *testing.T) {
+	req := require.New(t)
+
+	datasource := New("", "", MinTimeInterval(10*time.Second))
+	req.Equal("10s", datasource.builder.JSONData.(map[string]interface{})["timeInterval"])
+}
+
+func TestMaxSeries(t *testing.T) {
+	req := require.New(t)
+
+	datasource := New("", "", MaxSeries(43234))
+	req.Equal(43234, datasource.builder.JSONData.(map[string]interface{})["maxSeries"])
+}
+
+func TestBasicAuth(t *testing.T) {
+	req := require.New(t)
+
+	datasource := New("", "", BasicAuth("john", "doe"))
+	req.Equal(boolPtr(true), datasource.builder.BasicAuth)
+	req.Equal(stringPtr("john"), datasource.builder.BasicAuthUser)
+	req.Equal(stringPtr("doe"), datasource.builder.BasicAuthPassword)
+}
+
+func TestWithCredentials(t *testing.T) {
+	req := require.New(t)
+
+	datasource := New("", "", WithCredentials())
+	req.Equal(true, datasource.builder.WithCredentials)
+}
+
+func TestSkipTLSVerify(t *testing.T) {
+	req := require.New(t)
+
+	datasource := New("", "", SkipTLSVerify())
+	req.Equal(true, datasource.builder.JSONData.(map[string]interface{})["tlsSkipVerify"])
+}
+
+func TestForwardOauthIdentity(t *testing.T) {
+	req := require.New(t)
+
+	datasource := New("", "", ForwardOauthIdentity())
+	req.Equal(true, datasource.builder.JSONData.(map[string]interface{})["oauthPassThru"])
+}
+
+func TestTLSClientAuth(t *testing.T) {
+	req := require.New(t)
+
+	datasource := New("", "", TLSClientAuth("Foo", "bar"))
+	req.Equal(true, datasource.builder.JSONData.(map[string]interface{})["tlsAuth"])
+	req.Equal("Foo", datasource.builder.SecureJSONData.(map[string]interface{})["tlsClientCert"])
+	req.Equal("bar", datasource.builder.SecureJSONData.(map[string]interface{})["tlsClientKey"])
+}
+
+func TestWithCACert(t *testing.T) {
+	req := require.New(t)
+
+	datasource := New("", "", WithCACert("bozo"))
+	req.Equal(true, datasource.builder.JSONData.(map[string]interface{})["tlsAuthWithCACert"])
+	req.Equal("bozo", datasource.builder.SecureJSONData.(map[string]interface{})["tlsCACert"])
+}
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds support for the [InfluxQL](https://grafana.com/docs/grafana/latest/datasources/influxdb/#influxql-classic-influxdb-query) InfluxDB datasource. 

Support for the [Flux query language](https://grafana.com/docs/grafana/latest/datasources/influxdb/influxdb-flux/#flux-query-language-in-grafana) will come in a next PR.

Surely need to run this against a real grafana now 😅 

Let me know what you think :)