### PR TITLE
[Add] GetDashboardByTitle

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/K-Phoen/grabana/alert"
@@ -330,7 +331,7 @@ func (client *Client) GetAlertChannelByName(ctx context.Context, name string) (*
 
 // GetDashboardByTitle finds a dashboard, given its title.
 func (client *Client) GetDashboardByTitle(ctx context.Context, title string) (*Dashboard, error) {
-	resp, err := client.get(ctx, fmt.Sprintf("/api/search?type=dash-db&query=%s", title))
+	resp, err := client.get(ctx, "/api/search?type=dash-db&query="+url.QueryEscape(title))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In this pull request I did this:

- Implemented GetDashboardByTitle. Its functionality is very similar to that of GetFolderByTitle
- Added more fields to the Dashboard struct for the API to return

You can try it out by doing this:
```
db, err := client.GetDashboardByTitle(ctx, "Awesome Dashboard")

if err != nil {
	fmt.Printf("Could not find dashboard: %s\n", err)
	os.Exit(1)
}

fmt.Println(db)
```
The above query returns `*Dashboard` and `error`