### PR TITLE
feat: add NewFromBoard func to dahsboard builder

### DIFF
--- a/dashboard/dashboard.go
+++ b/dashboard/dashboard.go
@@ -51,6 +51,12 @@ type Builder struct {
 	alerts []*alert.Alert
 }
 
+func NewFromBoard(board *sdk.Board) Builder {
+	return Builder{
+		board: board,
+	}
+}
+
 // New creates a new dashboard builder.
 func New(title string, options ...Option) (Builder, error) {
 	board := sdk.NewBoard(title)

--- a/dashboard/dashboard_test.go
+++ b/dashboard/dashboard_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/K-Phoen/grabana/variable/datasource"
+	"github.com/K-Phoen/sdk"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,6 +14,18 @@ func requireJSON(t *testing.T, payload []byte) {
 	if err := json.Unmarshal(payload, &receiver); err != nil {
 		t.Fatalf("invalid json: %s", err)
 	}
+}
+
+func TestNewDashboardsCanBeCreatedFromSdkBoard(t *testing.T) {
+	req := require.New(t)
+
+	testBoard := sdk.NewBoard("My dashboard")
+	testBoard.Timezone = "UTC"
+
+	builder := NewFromBoard(testBoard)
+
+	req.Equal("My dashboard", builder.board.Title)
+	req.Equal("UTC", builder.board.Timezone)
 }
 
 func TestNewDashboardsCanBeCreated(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Martin Chodur <m.chodur@seznam.cz>

Hi, this would make managing dashboards possible with the grabana client without necessarily using the grabana builder API (which does not support all properties of Grafana dashboard JSON) and create/manage also dashboards created using the sdk directly WDYT? 