### PR TITLE
Support dashboard links using tags

### DIFF
--- a/dashboard/link.go
+++ b/dashboard/link.go
@@ -18,6 +18,8 @@ const (
 // See https://grafana.com/docs/grafana/latest/linking/dashboard-links/
 type ExternalLink struct {
 	Title                 string
+	Type                  string
+	Tags                  []string
 	Description           string
 	URL                   string
 	Icon                  LinkIcon
@@ -41,8 +43,8 @@ func (link ExternalLink) asSdk() sdk.Link {
 		Icon:        &icon,
 		IncludeVars: link.IncludeVariableValues,
 		KeepTime:    &link.IncludeTimeRange,
-		Tags:        make([]string, 0),
+		Tags:        link.Tags,
 		TargetBlank: &link.OpenInNewTab,
-		Type:        "link",
+		Type:        link.Type,
 	}
 }

--- a/decoder/externallink.go
+++ b/decoder/externallink.go
@@ -6,17 +6,21 @@ import (
 
 type DashboardExternalLink struct {
 	Title                 string
-	URL                   string `yaml:"url"`
-	Description           string `yaml:",omitempty"`
-	Icon                  string `yaml:"icon,omitempty"`
-	IncludeTimeRange      bool   `yaml:"include_time_range,omitempty"`
-	IncludeVariableValues bool   `yaml:"include_variable_values,omitempty"`
-	OpenInNewTab          bool   `yaml:"open_in_new_tab,omitempty"`
+	Type                  string   `yaml:"type,omitempty"`
+	Tags                  []string `yaml:"tags,omitempty"`
+	URL                   string   `yaml:"url,omitempty"`
+	Description           string   `yaml:",omitempty"`
+	Icon                  string   `yaml:"icon,omitempty"`
+	IncludeTimeRange      bool     `yaml:"include_time_range,omitempty"`
+	IncludeVariableValues bool     `yaml:"include_variable_values,omitempty"`
+	OpenInNewTab          bool     `yaml:"open_in_new_tab,omitempty"`
 }
 
 func (l DashboardExternalLink) toModel() dashboard.ExternalLink {
 	return dashboard.ExternalLink{
 		Title:                 l.Title,
+		Type:                  l.Type,
+		Tags:                  l.Tags,
 		Description:           l.Description,
 		URL:                   l.URL,
 		Icon:                  dashboard.LinkIcon(l.Icon),

--- a/decoder/externallink_test.go
+++ b/decoder/externallink_test.go
@@ -11,6 +11,8 @@ func TestExternalLink(t *testing.T) {
 
 	yamlLink := DashboardExternalLink{
 		Title:                 "joe",
+		Type:                  "link",
+		Tags:                  make([]string, 0),
 		URL:                   "http://foo",
 		Description:           "bar",
 		Icon:                  "cloud",
@@ -22,6 +24,8 @@ func TestExternalLink(t *testing.T) {
 	model := yamlLink.toModel()
 
 	req.Equal("joe", model.Title)
+	req.Equal("link", model.Type)
+	req.Equal(0, len(model.Tags))
 	req.Equal("http://foo", model.URL)
 	req.Equal("bar", model.Description)
 	req.Equal("cloud", string(model.Icon))


### PR DESCRIPTION
Grafana supports linking to other grafana dashboard using grafana tags. This adds support for that in grabana.