### PR TITLE
add support for value mappings to stat panels.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,3 +31,5 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
+
+replace github.com/K-Phoen/sdk v0.12.2 => github.com/AndersSoee/grabana-sdk v0.0.0-20230502052338-319fd6875a4a

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/K-Phoen/sdk v0.12.2 h1:0QofDlKE+lloyBOzhjEEMW21061zts/WIpfpQ5NLLAs=
-github.com/K-Phoen/sdk v0.12.2/go.mod h1:qmM0wO23CtoDux528MXPpYvS4XkRWkWX6rvX9Za8EVU=
+github.com/AndersSoee/grabana-sdk v0.0.0-20230502052338-319fd6875a4a h1:1WbX3BNVuvi9b/XjA+k3WaiOFh5PVtFUneZpx+4mQSs=
+github.com/AndersSoee/grabana-sdk v0.0.0-20230502052338-319fd6875a4a/go.mod h1:qmM0wO23CtoDux528MXPpYvS4XkRWkWX6rvX9Za8EVU=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/stat/stat_test.go
+++ b/stat/stat_test.go
@@ -1,6 +1,7 @@
 package stat
 
 import (
+	"github.com/K-Phoen/sdk"
 	"testing"
 
 	"github.com/K-Phoen/grabana/errors"
@@ -426,6 +427,33 @@ func TestRelativeThresholdsCanBeConfigured(t *testing.T) {
 	req.Len(thresholds.Steps, 3)
 }
 
-func float64Ptr(input float64) *float64 {
-	return &input
+func TestValueMappingsCanBeConfigured(t *testing.T) {
+	req := require.New(t)
+
+	panel, err := New("",
+		ValueMappings(
+			RangeMapping(0.0, 0.9).Text("DOWN"),
+			RangeMapping(1, 1.0).Text("UP"),
+			ValueMapping("UP").Color("red"),
+			SpecialMapping(SpecialNaN).Color("yellow"),
+			RegexMapping(".*").Color("blue"),
+		),
+	)
+
+	req.NoError(err)
+
+	mappings := panel.Builder.StatPanel.FieldConfig.Defaults.ValueMappings
+
+	req.Len(mappings, 5)
+
+	req.Equal("range", mappings[0].MappingType)
+	req.Equal(0.9, mappings[0].Options["to"])
+	result0, ok := mappings[0].Options["result"].(*sdk.ValueMappingResult)
+	req.True(ok)
+	req.Equal("DOWN", *result0.Text)
+
+	req.Equal("value", mappings[2].MappingType)
+	result2, ok := mappings[2].Options["UP"].(*sdk.ValueMappingResult)
+	req.True(ok)
+	req.Equal("red", *result2.Color)
 }

--- a/vendor/github.com/K-Phoen/sdk/panel.go
+++ b/vendor/github.com/K-Phoen/sdk/panel.go
@@ -47,6 +47,15 @@ const (
 
 const MixedSource = "-- Mixed --"
 
+type MappingType string
+
+const (
+	MappingTypeRange   MappingType = "range"
+	MappingTypeRegex   MappingType = "regex"
+	MappingTypeSpecial MappingType = "special"
+	MappingTypeValue   MappingType = "value"
+)
+
 type (
 	// Panel represents panels of different types defined in Grafana.
 	Panel struct {
@@ -340,15 +349,16 @@ type (
 		Mode string `json:"mode"`
 	}
 	FieldConfigDefaults struct {
-		Unit       string            `json:"unit"`
-		NoValue    string            `json:"noValue,omitempty"`
-		Decimals   *int              `json:"decimals,omitempty"`
-		Min        *float64          `json:"min,omitempty"`
-		Max        *float64          `json:"max,omitempty"`
-		Color      FieldConfigColor  `json:"color"`
-		Thresholds Thresholds        `json:"thresholds"`
-		Custom     FieldConfigCustom `json:"custom"`
-		Links      []Link            `json:"links,omitempty"`
+		Unit          string            `json:"unit"`
+		NoValue       string            `json:"noValue,omitempty"`
+		Decimals      *int              `json:"decimals,omitempty"`
+		Min           *float64          `json:"min,omitempty"`
+		Max           *float64          `json:"max,omitempty"`
+		Color         FieldConfigColor  `json:"color"`
+		Thresholds    Thresholds        `json:"thresholds"`
+		Custom        FieldConfigCustom `json:"custom"`
+		Links         []Link            `json:"links,omitempty"`
+		ValueMappings []ValueMapping    `json:"mappings,omitempty"`
 	}
 	FieldConfigOverrideProperty struct {
 		ID    string      `json:"id"`
@@ -524,7 +534,29 @@ type (
 		YMin      *float64 `json:"ymin,omitempty"`
 		YMax      *float64 `json:"ymax,omitempty"`
 	}
+	ValueMapping struct {
+		MappingType string                 `json:"type,omitempty"`
+		Options     map[string]interface{} `json:"options,omitempty"`
+	}
+	ValueMappingsOptions struct {
+		From    *float64           `json:"from,omitempty"`
+		To      *float64           `json:"to,omitempty"`
+		Pattern *string            `json:"pattern,omitempty"`
+		Match   *string            `json:"match,omitempty"`
+		Result  ValueMappingResult `json:"result,omitempty"`
+	}
+	ValueMappingResult struct {
+		Text  *string `json:"text,omitempty"`
+		Color *string `json:"color,omitempty"`
+		Index *int    `json:"index,omitempty"`
+	}
 )
+
+const MappingOptionFrom = "from"
+const MappingOptionTo = "to"
+const MappingOptionPattern = "pattern"
+const MappingOptionMatch = "match"
+const MappingOptionResult = "result"
 
 // for an any panel
 type Target struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/K-Phoen/sdk v0.12.2
+# github.com/K-Phoen/sdk v0.12.2 => github.com/AndersSoee/grabana-sdk v0.0.0-20230502052338-319fd6875a4a
 ## explicit; go 1.19
 github.com/K-Phoen/sdk
 # github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
Fixes https://github.com/K-Phoen/grabana/issues/222

Requires PR for sdk lib : https://github.com/K-Phoen/sdk/pull/22

Enables usage in the form:
```
		stat.ValueMappings(
			stat.RangeMapping(0, 0.9).Text("DOWN").Color("red"),
			stat.RangeMapping(1, 1).Text("UP"),
			stat.ValueMapping("UP").Color("green"),
		),
```