### PR TITLE
adding all fields that grafana sdk's board supports to Dashboard struct

### DIFF
--- a/dashboards.go
+++ b/dashboards.go
@@ -18,16 +18,13 @@ var ErrDashboardNotFound = errors.New("dashboard not found")
 
 // Dashboard represents a Grafana dashboard.
 type Dashboard struct {
-	ID          int      `json:"id"`
-	UID         string   `json:"uid"`
-	Title       string   `json:"title"`
-	URL         string   `json:"url"`
-	Tags        []string `json:"tags"`
-	IsStarred   bool     `json:"isStarred"`
-	FolderID    int      `json:"folderId"`
-	FolderUID   string   `json:"folderUid"`
-	FolderTitle string   `json:"folderTitle"`
-	FolderURL   string   `json:"folderUrl"`
+	*sdk.Board
+	URL         string `json:"url"`
+	IsStarred   bool   `json:"isStarred"`
+	FolderID    int    `json:"folderId"`
+	FolderUID   string `json:"folderUid"`
+	FolderTitle string `json:"folderTitle"`
+	FolderURL   string `json:"folderUrl"`
 }
 
 // GetDashboardByTitle finds a dashboard, given its title.


### PR DESCRIPTION
I have a use case to access the templating data from the JSON object returned in GetDashboardByTitle method [here](https://github.com/K-Phoen/grabana/blob/e25e5647caf9b77083222f71301b127de5e0380c/dashboards.go#LL47C1-L49C3). So adding the board struct that we get from grafana sdk to include all the fields. 