### PR TITLE
Allow ProjectName to be configurable on Stackdriver alerts

### DIFF
--- a/alert/queries/stackdriver/stackdriver.go
+++ b/alert/queries/stackdriver/stackdriver.go
@@ -146,6 +146,13 @@ func Legend(legend string) Option {
 	}
 }
 
+// Project defines the GCP project to use for this target.
+func Project(project string) Option {
+	return func(stackdriver *Stackdriver) {
+		stackdriver.Builder.Model.MetricQuery.ProjectName = project
+	}
+}
+
 // Aggregation defines how the time series will be aggregated.
 func Aggregation(reducer Reducer) Option {
 	return func(stackdriver *Stackdriver) {

--- a/alert/queries/stackdriver/stackdriver_test.go
+++ b/alert/queries/stackdriver/stackdriver_test.go
@@ -7,6 +7,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestProjectCanBeConfigured(t *testing.T) {
+	req := require.New(t)
+	
+	project := "some-gcp-project-id"
+
+	query := Delta("A", "some metric", Project(project))
+
+	builder := query.Builder
+
+	req.Equal(project, builder.Model.MetricQuery.ProjectName)
+}
+
 func TestDeltaQueriesCanBeCreated(t *testing.T) {
 	req := require.New(t)
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/K-Phoen/grabana
 go 1.19
 
 require (
-	github.com/K-Phoen/sdk v0.12.2
+	github.com/K-Phoen/sdk v0.12.3-0.20230811095259-e77b6356006c
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/prometheus/common v0.39.0
 	github.com/rhysd/go-github-selfupdate v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/K-Phoen/sdk v0.12.2 h1:0QofDlKE+lloyBOzhjEEMW21061zts/WIpfpQ5NLLAs=
 github.com/K-Phoen/sdk v0.12.2/go.mod h1:qmM0wO23CtoDux528MXPpYvS4XkRWkWX6rvX9Za8EVU=
+github.com/K-Phoen/sdk v0.12.3-0.20230811095259-e77b6356006c h1:HhFwUniM6YC8r3jOZBOZkCNrmNTcGGP/1+lCFNigmbw=
+github.com/K-Phoen/sdk v0.12.3-0.20230811095259-e77b6356006c/go.mod h1:qmM0wO23CtoDux528MXPpYvS4XkRWkWX6rvX9Za8EVU=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/vendor/github.com/K-Phoen/sdk/alert.go
+++ b/vendor/github.com/K-Phoen/sdk/alert.go
@@ -74,6 +74,7 @@ type AlertModel struct {
 }
 
 type StackdriverAlertQuery struct {
+	ProjectName        string                    `json:"projectName,omitempty"`
 	AlignOptions       []StackdriverAlignOptions `json:"alignOptions,omitempty"`
 	AliasBy            string                    `json:"aliasBy,omitempty"`
 	MetricType         string                    `json:"metricType,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/K-Phoen/sdk v0.12.2
+# github.com/K-Phoen/sdk v0.12.3-0.20230811095259-e77b6356006c
 ## explicit; go 1.19
 github.com/K-Phoen/sdk
 # github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
Utilising the now exposed ProjectName as added in SDK https://github.com/K-Phoen/sdk/commit/e77b6356006cbe3533e72da4479810cad23a6103.

Note: This PR is referring to a specific SDK commit as a release isn't available yet. Please create a new release of the [SDK](https://github.com/K-Phoen/sdk) and I'll fix this PR.