### PR TITLE
Introduce support to override alert rule name

### DIFF
--- a/alert/alert.go
+++ b/alert/alert.go
@@ -133,6 +133,13 @@ func (alert *Alert) HookPanelID(id string) {
 	}
 }
 
+// Name sets the name associated to the alert.
+func Name(name string) Option {
+	return func(alert *Alert) {
+		alert.Builder.Rules[0].GrafanaAlert.Title = name
+	}
+}
+
 // Summary sets the summary associated to the alert.
 func Summary(content string) Option {
 	return func(alert *Alert) {


### PR DESCRIPTION
Currently, the alert rule is provisioned with a Title that matches the panel title. The `Alert` constructor function receives a `name`  argument but misleadingly sets that value as the alert rule's `Summary` instead of `AlertRule.Title`.

The provisioned dashboard panels can have generic names like "traffic" or "latency", but their corresponding Alert Rules need to have more specific titles, e.g.:

- my-service traffic alarm
- my-service latency alarm

Hence, this PR will allow the operator to utilize an `alert.name()` option.