### PR TITLE
Support multiple alerts in Graph and TimeSeries panels

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -74,12 +74,12 @@ const (
 // Graph represents a graph panel.
 type Graph struct {
 	Builder *sdk.Panel
-	Alert   *alert.Alert
+	Alerts  []*alert.Alert
 }
 
 // New creates a new graph panel.
 func New(title string, options ...Option) (*Graph, error) {
-	panel := &Graph{Builder: sdk.NewGraph(title)}
+	panel := &Graph{Builder: sdk.NewGraph(title), Alerts: make([]*alert.Alert, 0)}
 
 	panel.Builder.AliasColors = make(map[string]interface{})
 	panel.Builder.IsNew = false
@@ -266,8 +266,9 @@ func XAxis(opts ...axis.Option) Option {
 // Alert creates an alert for this graph.
 func Alert(name string, opts ...alert.Option) Option {
 	return func(graph *Graph) error {
-		graph.Alert = alert.New(graph.Builder.Title, append(opts, alert.Summary(name))...)
-		graph.Alert.Builder.Name = graph.Builder.Title
+		al := alert.New(graph.Builder.Title, append(opts, alert.Summary(name))...)
+		al.Builder.Name = graph.Builder.Title
+		graph.Alerts = append(graph.Alerts, al)
 
 		return nil
 	}

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -158,8 +158,21 @@ func TestAlertsCanBeConfigured(t *testing.T) {
 	panel, err := New("panel title", Alert("some alert"))
 
 	req.NoError(err)
-	req.NotNil(panel.Alert)
-	req.Equal("panel title", panel.Alert.Builder.Name)
+	req.NotNil(panel.Alerts)
+	req.Len(panel.Alerts, 1)
+	req.Equal("panel title", panel.Alerts[0].Builder.Name)
+}
+
+func TestTwoAlertsCanBeConfigured(t *testing.T) {
+	req := require.New(t)
+
+	panel, err := New("panel title", Alert("some alert"), Alert("other alert"))
+
+	req.NoError(err)
+	req.NotNil(panel.Alerts)
+	req.Len(panel.Alerts, 2)
+	req.Equal("panel title", panel.Alerts[0].Builder.Name)
+	req.Equal("panel title", panel.Alerts[1].Builder.Name)
 }
 
 func TestDrawModeCanBeConfigured(t *testing.T) {

--- a/row/row.go
+++ b/row/row.go
@@ -58,15 +58,17 @@ func WithGraph(title string, options ...graph.Option) Option {
 
 		row.builder.Add(panel.Builder)
 
-		if panel.Alert == nil {
+		if panel.Alerts == nil || len(panel.Alerts) == 0 {
 			return nil
 		}
 
-		if panel.Builder.Datasource != nil {
-			panel.Alert.Datasource = panel.Builder.Datasource.LegacyName
-		}
+		for _, al := range panel.Alerts {
+			if panel.Builder.Datasource != nil {
+				al.Datasource = panel.Builder.Datasource.LegacyName
+			}
 
-		row.alerts = append(row.alerts, panel.Alert)
+			row.alerts = append(row.alerts, al)
+		}
 
 		return nil
 	}
@@ -82,15 +84,17 @@ func WithTimeSeries(title string, options ...timeseries.Option) Option {
 
 		row.builder.Add(panel.Builder)
 
-		if panel.Alert == nil {
+		if panel.Alerts == nil || len(panel.Alerts) == 0 {
 			return nil
 		}
 
-		if panel.Builder.Datasource != nil {
-			panel.Alert.Datasource = panel.Builder.Datasource.LegacyName
-		}
+		for _, al := range panel.Alerts {
+			if panel.Builder.Datasource != nil {
+				al.Datasource = panel.Builder.Datasource.LegacyName
+			}
 
-		row.alerts = append(row.alerts, panel.Alert)
+			row.alerts = append(row.alerts, al)
+		}
 
 		return nil
 	}

--- a/row/row_test.go
+++ b/row/row_test.go
@@ -69,12 +69,20 @@ func TestRowsCanHaveGraphsAndAlert(t *testing.T) {
 				),
 				alert.If(alert.Avg, "A", alert.IsAbove(3)),
 			),
+			graph.Alert(
+				"No heap allocations",
+				alert.WithPrometheusQuery(
+					"A",
+					"sum(go_memstats_heap_alloc_bytes{app!=\"\"}) by (app)",
+				),
+				alert.If(alert.Avg, "A", alert.IsBelow(0.01)),
+			),
 		),
 	)
 
 	req.NoError(err)
 	req.Len(panel.builder.Panels, 1)
-	req.Len(panel.Alerts(), 1)
+	req.Len(panel.Alerts(), 2)
 
 	req.Equal("Prometheus", panel.Alerts()[0].Datasource)
 }
@@ -107,12 +115,20 @@ func TestRowsCanHaveTimeSeriesAndAlert(t *testing.T) {
 				),
 				alert.If(alert.Avg, "A", alert.IsAbove(3)),
 			),
+			timeseries.Alert(
+				"No heap allocations",
+				alert.WithPrometheusQuery(
+					"A",
+					"sum(go_memstats_heap_alloc_bytes{app!=\"\"}) by (app)",
+				),
+				alert.If(alert.Avg, "A", alert.IsBelow(0.01)),
+			),
 		),
 	)
 
 	req.NoError(err)
 	req.Len(panel.builder.Panels, 1)
-	req.Len(panel.Alerts(), 1)
+	req.Len(panel.Alerts(), 2)
 
 	req.Equal("Prometheus", panel.Alerts()[0].Datasource)
 }

--- a/timeseries/timeseries.go
+++ b/timeseries/timeseries.go
@@ -123,12 +123,12 @@ const (
 // TimeSeries represents a time series panel.
 type TimeSeries struct {
 	Builder *sdk.Panel
-	Alert   *alert.Alert
+	Alerts  []*alert.Alert
 }
 
 // New creates a new time series panel.
 func New(title string, options ...Option) (*TimeSeries, error) {
-	panel := &TimeSeries{Builder: sdk.NewTimeseries(title)}
+	panel := &TimeSeries{Builder: sdk.NewTimeseries(title), Alerts: make([]*alert.Alert, 0)}
 	panel.Builder.IsNew = false
 
 	for _, opt := range append(defaults(), options...) {
@@ -409,8 +409,9 @@ func Transparent() Option {
 // Alert creates an alert for this graph.
 func Alert(name string, opts ...alert.Option) Option {
 	return func(timeseries *TimeSeries) error {
-		timeseries.Alert = alert.New(timeseries.Builder.Title, append(opts, alert.Summary(name))...)
-		timeseries.Alert.Builder.Name = timeseries.Builder.Title
+		al := alert.New(timeseries.Builder.Title, append(opts, alert.Summary(name))...)
+		al.Builder.Name = timeseries.Builder.Title
+		timeseries.Alerts = append(timeseries.Alerts, al)
 
 		return nil
 	}

--- a/timeseries/timeseries_test.go
+++ b/timeseries/timeseries_test.go
@@ -144,8 +144,21 @@ func TestAlertsCanBeConfigured(t *testing.T) {
 	panel, err := New("panel title", Alert("some alert"))
 
 	req.NoError(err)
-	req.NotNil(panel.Alert)
-	req.Equal("panel title", panel.Alert.Builder.Name)
+	req.NotNil(panel.Alerts)
+	req.Len(panel.Alerts, 1)
+	req.Equal("panel title", panel.Alerts[0].Builder.Name)
+}
+
+func TestTwoAlertsCanBeConfigured(t *testing.T) {
+	req := require.New(t)
+
+	panel, err := New("panel title", Alert("some alert"), Alert("other alert"))
+
+	req.NoError(err)
+	req.NotNil(panel.Alerts)
+	req.Len(panel.Alerts, 2)
+	req.Equal("panel title", panel.Alerts[0].Builder.Name)
+	req.Equal("panel title", panel.Alerts[1].Builder.Name)
 }
 
 func TestLineWidthCanBeConfigured(t *testing.T) {


### PR DESCRIPTION
The previous implementation only supported a single alert per Graph and TimeSeries. The current changes introduce the ability to configure multiple alerts per panel.