### PR TITLE
feat(folders): use API search endpoint for testing folder existence

### DIFF
--- a/folders.go
+++ b/folders.go
@@ -70,7 +70,7 @@ func (client *Client) CreateFolder(ctx context.Context, name string) (*Folder, e
 
 // GetFolderByTitle finds a folder, given its title.
 func (client *Client) GetFolderByTitle(ctx context.Context, title string) (*Folder, error) {
-	resp, err := client.get(ctx, fmt.Sprintf("/api/search?query=%s", url.QueryEscape(title)))
+	resp, err := client.get(ctx, fmt.Sprintf("/api/search?type=dash-folder&query=%s", url.QueryEscape(title)))
 	if err != nil {
 		return nil, err
 	}

--- a/folders.go
+++ b/folders.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -69,7 +70,7 @@ func (client *Client) CreateFolder(ctx context.Context, name string) (*Folder, e
 
 // GetFolderByTitle finds a folder, given its title.
 func (client *Client) GetFolderByTitle(ctx context.Context, title string) (*Folder, error) {
-	resp, err := client.get(ctx, "/api/folders?limit=1000")
+	resp, err := client.get(ctx, fmt.Sprintf("/api/search?query=%s", url.QueryEscape(title)))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Uses the [API search endpoint](https://grafana.com/docs/grafana/latest/developers/http_api/folder_dashboard_search/#search-folders-and-dashboards) to check if a dashboard folder exists. 

[Former API endpoint](https://grafana.com/docs/grafana/latest/developers/http_api/folder_dashboard_search/#search-folders-and-dashboards) returns only root level folders.

This is meant to be a step forward into the full support of nested folders mentioned in #261 .